### PR TITLE
feat: improve translation system thread safety, locale handling, and DX

### DIFF
--- a/pluginbase-core/src/main/java/dev/demeng/pluginbase/locale/Locales.java
+++ b/pluginbase-core/src/main/java/dev/demeng/pluginbase/locale/Locales.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * An enum-like class for packing all the available locales in Lamp.
+ * An enum-like class for packing all available locales supported by the framework.
  *
  * <p>Due to the fact that {@link Locale} does not define all locales, additional ones are added.
  */
@@ -73,16 +73,42 @@ public final class Locales {
   public static final Locale HUNGARIAN = new Locale("hu");
 
   /**
-   * Returns the locale that matches the given language.
+   * Returns the locale that matches the given language string. Handles case-insensitive matching
+   * and Minecraft client locale formats (e.g., "en_us", "pt_br", "zh_cn"). If no exact match is
+   * found, falls back to the base language (e.g., "en_GB" falls back to "en").
    *
    * <p>get("en") -> ENGLISH <br>
-   * get("fr") -> FRENCH
+   * get("fr") -> FRENCH <br>
+   * get("zh_cn") -> SIMPLIFIED_CHINESE <br>
+   * get("en_gb") -> ENGLISH (hierarchical fallback)
    *
    * @param language Language to get locale for
    * @return The locale, or null if not found.
    */
   public static Locale get(@NotNull final String language) {
-    return LOCALES.get(language);
+    Locale result = LOCALES.get(language);
+    if (result != null) {
+      return result;
+    }
+
+    final int underscore = language.indexOf('_');
+
+    if (underscore > 0 && underscore < language.length() - 1) {
+      final String normalized =
+          language.substring(0, underscore).toLowerCase(Locale.ROOT)
+              + "_"
+              + language.substring(underscore + 1).toUpperCase(Locale.ROOT);
+      result = LOCALES.get(normalized);
+      if (result != null) {
+        return result;
+      }
+    }
+
+    final String baseLang =
+        underscore > 0
+            ? language.substring(0, underscore).toLowerCase(Locale.ROOT)
+            : language.toLowerCase(Locale.ROOT);
+    return LOCALES.get(baseLang);
   }
 
   /**

--- a/pluginbase-core/src/main/java/dev/demeng/pluginbase/locale/SimpleTranslator.java
+++ b/pluginbase-core/src/main/java/dev/demeng/pluginbase/locale/SimpleTranslator.java
@@ -30,20 +30,24 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 
 final class SimpleTranslator implements Translator {
 
   private static final String DEFAULT_RESOURCE_BUNDLE = "pluginbase";
-  private static final LinkedList<LocaleReader> EMPTY_LIST = new LinkedList<>();
+  private static final List<LocaleReader> EMPTY_LIST = Collections.emptyList();
+  private static final Logger LOGGER = Logger.getLogger(SimpleTranslator.class.getName());
 
-  private final Map<Locale, LinkedList<LocaleReader>> registeredBundles = new HashMap<>();
+  private final ConcurrentHashMap<Locale, List<LocaleReader>> registeredBundles =
+      new ConcurrentHashMap<>();
   private volatile Locale locale = Locale.ENGLISH;
 
   SimpleTranslator() {
@@ -51,7 +55,7 @@ final class SimpleTranslator implements Translator {
   }
 
   public void loadDefault() {
-    addResourceBundle(DEFAULT_RESOURCE_BUNDLE);
+    addResourceBundleSilent(getClass().getClassLoader(), DEFAULT_RESOURCE_BUNDLE);
   }
 
   @Override
@@ -115,14 +119,54 @@ final class SimpleTranslator implements Translator {
         return registeredBundle.get(key);
       }
     }
+    LOGGER.fine(
+        () ->
+            "Translation key not found: \""
+                + key
+                + "\" (requested: "
+                + locale
+                + ", default: "
+                + this.locale
+                + ")");
     return key;
   }
 
   @Override
+  public @NotNull String @NotNull [] getArray(@NotNull final String key) {
+    return getArray(key, locale);
+  }
+
+  @Override
+  public @NotNull String @NotNull [] getArray(
+      @NotNull final String key, @NotNull final Locale locale) {
+    for (final LocaleReader registeredBundle : registeredBundles.getOrDefault(locale, EMPTY_LIST)) {
+      if (registeredBundle.containsKey(key)) {
+        return registeredBundle.getArray(key);
+      }
+    }
+    for (final LocaleReader registeredBundle :
+        registeredBundles.getOrDefault(this.locale, EMPTY_LIST)) {
+      if (registeredBundle.containsKey(key)) {
+        return registeredBundle.getArray(key);
+      }
+    }
+    LOGGER.fine(
+        () ->
+            "Translation array key not found: \""
+                + key
+                + "\" (requested: "
+                + locale
+                + ", default: "
+                + this.locale
+                + ")");
+    return new String[] {key};
+  }
+
+  @Override
   public void add(@NotNull final LocaleReader reader) {
-    final LinkedList<LocaleReader> list =
-        registeredBundles.computeIfAbsent(reader.getLocale(), v -> new LinkedList<>());
-    list.push(reader);
+    registeredBundles
+        .computeIfAbsent(reader.getLocale(), v -> new CopyOnWriteArrayList<>())
+        .add(0, reader);
   }
 
   @Override
@@ -140,26 +184,42 @@ final class SimpleTranslator implements Translator {
       @NotNull final ClassLoader loader,
       @NotNull final String resourceBundle,
       @NotNull final Locale... locales) {
+    int loaded = 0;
     for (final Locale l : locales) {
       try {
         final ResourceBundle bundle =
             ResourceBundle.getBundle(resourceBundle, l, loader, UTF8Control.INSTANCE);
         add(bundle);
+        loaded++;
       } catch (final MissingResourceException ignored) {
       }
+    }
+    if (loaded == 0 && locales.length > 0) {
+      LOGGER.warning(
+          () ->
+              "No resource bundles found for \""
+                  + resourceBundle
+                  + "\" across "
+                  + locales.length
+                  + " locale(s)");
     }
   }
 
   @Override
   public void addResourceBundle(
       @NotNull final ClassLoader loader, @NotNull final String resourceBundle) {
+    int loaded = 0;
     for (final Locale l : Locales.getLocales()) {
       try {
         final ResourceBundle bundle =
             ResourceBundle.getBundle(resourceBundle, l, loader, UTF8Control.INSTANCE);
         add(bundle);
+        loaded++;
       } catch (final MissingResourceException ignored) {
       }
+    }
+    if (loaded == 0) {
+      LOGGER.warning(() -> "No resource bundles found for \"" + resourceBundle + "\"");
     }
   }
 
@@ -171,5 +231,17 @@ final class SimpleTranslator implements Translator {
   @Override
   public void add(@NotNull final ResourceBundle resourceBundle) {
     add(LocaleReader.wrap(resourceBundle));
+  }
+
+  private void addResourceBundleSilent(
+      @NotNull final ClassLoader loader, @NotNull final String resourceBundle) {
+    for (final Locale l : Locales.getLocales()) {
+      try {
+        final ResourceBundle bundle =
+            ResourceBundle.getBundle(resourceBundle, l, loader, UTF8Control.INSTANCE);
+        add(bundle);
+      } catch (final MissingResourceException ignored) {
+      }
+    }
   }
 }

--- a/pluginbase-core/src/main/java/dev/demeng/pluginbase/locale/Translator.java
+++ b/pluginbase-core/src/main/java/dev/demeng/pluginbase/locale/Translator.java
@@ -83,6 +83,31 @@ public interface Translator {
   String get(@NotNull String key, @NotNull Locale locale);
 
   /**
+   * Returns the message array that corresponds to the given key, using the current {@link
+   * #getLocale()}. Useful for multi-line translations such as item lore. If no such message is
+   * found, a single-element array containing the key will be returned.
+   *
+   * @param key Message key to fetch with
+   * @return The translated message array, or a single-element array of the key if not found.
+   */
+  default @NotNull String @NotNull [] getArray(@NotNull String key) {
+    return new String[] {get(key)};
+  }
+
+  /**
+   * Returns the message array that corresponds to the given key, using the given locale. Useful for
+   * multi-line translations such as item lore. If no such message is found, a single-element array
+   * containing the key will be returned.
+   *
+   * @param key Message key to fetch with
+   * @param locale Locale to get with
+   * @return The translated message array, or a single-element array of the key if not found.
+   */
+  default @NotNull String @NotNull [] getArray(@NotNull String key, @NotNull Locale locale) {
+    return new String[] {get(key, locale)};
+  }
+
+  /**
    * Adds the given locale reader to this translator.
    *
    * @param reader The locale reader to add

--- a/pluginbase-core/src/main/java/dev/demeng/pluginbase/menu/model/MenuButton.java
+++ b/pluginbase-core/src/main/java/dev/demeng/pluginbase/menu/model/MenuButton.java
@@ -26,12 +26,14 @@ package dev.demeng.pluginbase.menu.model;
 
 import dev.demeng.pluginbase.menu.layout.Menu;
 import dev.demeng.pluginbase.serialize.ItemSerializer;
+import java.util.Locale;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
@@ -148,5 +150,179 @@ public class MenuButton {
       @NotNull final ConfigurationSection section,
       @Nullable final Consumer<InventoryClickEvent> consumer) {
     return create(slot, section, null, consumer);
+  }
+
+  // ---------------------------------------------------------------------------------
+  // LOCALIZED FACTORY METHODS
+  // ---------------------------------------------------------------------------------
+
+  /**
+   * Creates a new menu button from a configuration section with localization support. Translation
+   * key placeholders ({@code #{key}}) in item strings will be resolved using the given locale. The
+   * slot will always be subtracted by 1.
+   *
+   * @param section The configuration section containing the button information
+   * @param locale The locale to use for localization
+   * @param transformer Additional transformer for strings in the item, applied after localization
+   * @param consumer The consumer for the button
+   * @return The button from config
+   */
+  @NotNull
+  public static MenuButton createLocalized(
+      @NotNull final ConfigurationSection section,
+      @Nullable final Locale locale,
+      @Nullable final UnaryOperator<String> transformer,
+      @Nullable final Consumer<InventoryClickEvent> consumer) {
+
+    int slot = section.getInt("slot", 0);
+    if (slot > 0) {
+      slot--;
+    }
+    return create(
+        slot, ItemSerializer.deserializeLocalized(section, locale, transformer), consumer);
+  }
+
+  /**
+   * Creates a new menu button from a configuration section with localization support. Translation
+   * key placeholders ({@code #{key}}) in item strings will be resolved using the given locale. The
+   * slot will always be subtracted by 1.
+   *
+   * @param section The configuration section containing the button information
+   * @param locale The locale to use for localization
+   * @param consumer The consumer for the button
+   * @return The button from config
+   */
+  @NotNull
+  public static MenuButton createLocalized(
+      @NotNull final ConfigurationSection section,
+      @Nullable final Locale locale,
+      @Nullable final Consumer<InventoryClickEvent> consumer) {
+    return createLocalized(section, locale, null, consumer);
+  }
+
+  /**
+   * Creates a new menu button from a configuration section with localization support, using the
+   * sender's locale. The slot will always be subtracted by 1.
+   *
+   * @param section The configuration section containing the button information
+   * @param sender The command sender whose locale will be used
+   * @param transformer Additional transformer for strings in the item, applied after localization
+   * @param consumer The consumer for the button
+   * @return The button from config
+   */
+  @NotNull
+  public static MenuButton createLocalized(
+      @NotNull final ConfigurationSection section,
+      @NotNull final CommandSender sender,
+      @Nullable final UnaryOperator<String> transformer,
+      @Nullable final Consumer<InventoryClickEvent> consumer) {
+
+    int slot = section.getInt("slot", 0);
+    if (slot > 0) {
+      slot--;
+    }
+    return create(
+        slot, ItemSerializer.deserializeLocalized(section, sender, transformer), consumer);
+  }
+
+  /**
+   * Creates a new menu button from a configuration section with localization support, using the
+   * sender's locale. The slot will always be subtracted by 1.
+   *
+   * @param section The configuration section containing the button information
+   * @param sender The command sender whose locale will be used
+   * @param consumer The consumer for the button
+   * @return The button from config
+   */
+  @NotNull
+  public static MenuButton createLocalized(
+      @NotNull final ConfigurationSection section,
+      @NotNull final CommandSender sender,
+      @Nullable final Consumer<InventoryClickEvent> consumer) {
+    return createLocalized(section, sender, null, consumer);
+  }
+
+  /**
+   * Creates a new menu button from a configuration section with localization support, overriding
+   * the slot. Unlike the non-slot variant, the slot is not subtracted by 1.
+   *
+   * @param slot The slot of the button
+   * @param section The configuration section containing the button information
+   * @param locale The locale to use for localization
+   * @param transformer Additional transformer for strings in the item
+   * @param consumer The consumer for the button
+   * @return The button from config
+   */
+  @NotNull
+  public static MenuButton createLocalized(
+      final int slot,
+      @NotNull final ConfigurationSection section,
+      @Nullable final Locale locale,
+      @Nullable final UnaryOperator<String> transformer,
+      @Nullable final Consumer<InventoryClickEvent> consumer) {
+    return create(
+        slot, ItemSerializer.deserializeLocalized(section, locale, transformer), consumer);
+  }
+
+  /**
+   * Creates a new menu button from a configuration section with localization support, overriding
+   * the slot. Unlike the non-slot variant, the slot is not subtracted by 1.
+   *
+   * @param slot The slot of the button
+   * @param section The configuration section containing the button information
+   * @param locale The locale to use for localization
+   * @param consumer The consumer for the button
+   * @return The button from config
+   */
+  @NotNull
+  public static MenuButton createLocalized(
+      final int slot,
+      @NotNull final ConfigurationSection section,
+      @Nullable final Locale locale,
+      @Nullable final Consumer<InventoryClickEvent> consumer) {
+    return createLocalized(slot, section, locale, null, consumer);
+  }
+
+  /**
+   * Creates a new menu button from a configuration section with localization support, overriding
+   * the slot, using the sender's locale. Unlike the non-slot variant, the slot is not subtracted by
+   * 1.
+   *
+   * @param slot The slot of the button
+   * @param section The configuration section containing the button information
+   * @param sender The command sender whose locale will be used
+   * @param transformer Additional transformer for strings in the item
+   * @param consumer The consumer for the button
+   * @return The button from config
+   */
+  @NotNull
+  public static MenuButton createLocalized(
+      final int slot,
+      @NotNull final ConfigurationSection section,
+      @NotNull final CommandSender sender,
+      @Nullable final UnaryOperator<String> transformer,
+      @Nullable final Consumer<InventoryClickEvent> consumer) {
+    return create(
+        slot, ItemSerializer.deserializeLocalized(section, sender, transformer), consumer);
+  }
+
+  /**
+   * Creates a new menu button from a configuration section with localization support, overriding
+   * the slot, using the sender's locale. Unlike the non-slot variant, the slot is not subtracted by
+   * 1.
+   *
+   * @param slot The slot of the button
+   * @param section The configuration section containing the button information
+   * @param sender The command sender whose locale will be used
+   * @param consumer The consumer for the button
+   * @return The button from config
+   */
+  @NotNull
+  public static MenuButton createLocalized(
+      final int slot,
+      @NotNull final ConfigurationSection section,
+      @NotNull final CommandSender sender,
+      @Nullable final Consumer<InventoryClickEvent> consumer) {
+    return createLocalized(slot, section, sender, null, consumer);
   }
 }

--- a/pluginbase-core/src/main/java/dev/demeng/pluginbase/text/Text.java
+++ b/pluginbase-core/src/main/java/dev/demeng/pluginbase/text/Text.java
@@ -111,7 +111,7 @@ public final class Text {
         }
       }
 
-      final Locale locale = Locales.get(playerLocale);
+      final Locale locale = Locales.get(playerLocale.trim());
       return locale == null ? BaseManager.getTranslator().getLocale() : locale;
     }
 
@@ -121,6 +121,10 @@ public final class Text {
   /**
    * Gets the localized string with the given key using the provided sender's locale. Uses the
    * default locale if the localized string could not be resolved with the provided sender's locale.
+   *
+   * <p>Uses {@link MessageFormat} internally for argument substitution. Single quotes in
+   * translation values must be doubled ({@code ''}) to appear literally, and curly braces used as
+   * literal text (not placeholders) must be quoted: {@code '{literal}'}.
    *
    * @param key The key of the message
    * @param sender The sender to get the locale of
@@ -145,6 +149,10 @@ public final class Text {
    * Gets the localized string with the given key using the provided locale. Uses the default locale
    * if the localized string could not be resolved with the provided locale.
    *
+   * <p>Uses {@link MessageFormat} internally for argument substitution. Single quotes in
+   * translation values must be doubled ({@code ''}) to appear literally, and curly braces used as
+   * literal text (not placeholders) must be quoted: {@code '{literal}'}.
+   *
    * @param key The key of the message
    * @param locale The locale
    * @param args Arguments for positioned placeholders ({n})
@@ -167,6 +175,9 @@ public final class Text {
 
   /**
    * Gets the localized string with the given key using the default locale.
+   *
+   * <p>Uses {@link MessageFormat} internally for argument substitution. Single quotes in
+   * translation values must be doubled ({@code ''}) to appear literally.
    *
    * @param key The key of the message
    * @param args Arguments for positioned placeholders ({n})
@@ -226,6 +237,9 @@ public final class Text {
   /**
    * Localizes the placeholders in the string using the sender's locale. Note that the same
    * arguments are used for EVERY placeholder.
+   *
+   * <p>Each resolved placeholder is processed through {@link MessageFormat}. Single quotes in
+   * translation values must be doubled ({@code ''}) to appear literally.
    *
    * @param str The string to localize
    * @param locale The locale to use
@@ -625,6 +639,9 @@ public final class Text {
    * the command sender. Any key equaling null or any message equaling to {@link
    * #IGNORE_MESSAGE_VALUE} (ignore case) will be ignored.
    *
+   * <p>Uses {@link MessageFormat} internally for argument substitution. Single quotes in
+   * translation values must be doubled ({@code ''}) to appear literally.
+   *
    * @param sender The command sender that will receive the message
    * @param key The key of the localized string
    * @param args Arguments to replace in the localized string
@@ -670,6 +687,9 @@ public final class Text {
    * Does the same thing as {@link #tellLocalized(CommandSender, String, Object...)}, but without
    * the prefix. Any key equaling null or any message equaling to {@link #IGNORE_MESSAGE_VALUE}
    * (ignore case) will be ignored.
+   *
+   * <p>Uses {@link MessageFormat} internally for argument substitution. Single quotes in
+   * translation values must be doubled ({@code ''}) to appear literally.
    *
    * @param sender The command sender that will receive the message
    * @param key The key of the localized string

--- a/pluginbase-core/src/test/java/dev/demeng/pluginbase/locale/LocalesTest.java
+++ b/pluginbase-core/src/test/java/dev/demeng/pluginbase/locale/LocalesTest.java
@@ -1,0 +1,57 @@
+package dev.demeng.pluginbase.locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+class LocalesTest {
+
+  @Test
+  void exactLanguageMatch() {
+    assertThat(Locales.get("en")).isEqualTo(Locales.ENGLISH);
+    assertThat(Locales.get("fr")).isEqualTo(Locales.FRENCH);
+    assertThat(Locales.get("de")).isEqualTo(Locales.GERMAN);
+  }
+
+  @Test
+  void exactLanguageCountryMatch() {
+    assertThat(Locales.get("zh_CN")).isEqualTo(Locales.SIMPLIFIED_CHINESE);
+    assertThat(Locales.get("zh_TW")).isEqualTo(Locales.TRADITIONAL_CHINESE);
+  }
+
+  @Test
+  void minecraftLowercaseFormat() {
+    assertThat(Locales.get("zh_cn")).isEqualTo(Locales.SIMPLIFIED_CHINESE);
+    assertThat(Locales.get("zh_tw")).isEqualTo(Locales.TRADITIONAL_CHINESE);
+  }
+
+  @Test
+  void hierarchicalFallbackToBaseLanguage() {
+    assertThat(Locales.get("en_gb")).isEqualTo(Locales.ENGLISH);
+    assertThat(Locales.get("en_us")).isEqualTo(Locales.ENGLISH);
+    assertThat(Locales.get("pt_br")).isEqualTo(Locales.PORTUGUESE);
+    assertThat(Locales.get("es_mx")).isEqualTo(Locales.SPANISH);
+  }
+
+  @Test
+  void caseInsensitiveLanguageOnly() {
+    assertThat(Locales.get("FR")).isEqualTo(Locales.FRENCH);
+    assertThat(Locales.get("De")).isEqualTo(Locales.GERMAN);
+  }
+
+  @Test
+  void unknownLocaleReturnsNull() {
+    assertThat(Locales.get("xx")).isNull();
+    assertThat(Locales.get("xx_YY")).isNull();
+  }
+
+  @Test
+  void getLocalesIsNotEmpty() {
+    int count = 0;
+    for (final Locale ignored : Locales.getLocales()) {
+      count++;
+    }
+    assertThat(count).isGreaterThan(20);
+  }
+}

--- a/pluginbase-core/src/test/java/dev/demeng/pluginbase/locale/SimpleTranslatorTest.java
+++ b/pluginbase-core/src/test/java/dev/demeng/pluginbase/locale/SimpleTranslatorTest.java
@@ -1,0 +1,185 @@
+package dev.demeng.pluginbase.locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SimpleTranslatorTest {
+
+  private SimpleTranslator translator;
+
+  @BeforeEach
+  void setUp() {
+    translator = new SimpleTranslator();
+  }
+
+  @Test
+  void getMissingKeyReturnsKey() {
+    assertThat(translator.get("missing.key")).isEqualTo("missing.key");
+  }
+
+  @Test
+  void getReturnsValueFromRegisteredReader() {
+    final LocaleReader reader = mockReader(Locale.ENGLISH, "greeting", "Hello");
+    translator.add(reader);
+
+    assertThat(translator.get("greeting")).isEqualTo("Hello");
+  }
+
+  @Test
+  void getFallsBackToDefaultLocale() {
+    final LocaleReader englishReader = mockReader(Locale.ENGLISH, "greeting", "Hello");
+    translator.add(englishReader);
+
+    assertThat(translator.get("greeting", Locale.FRENCH)).isEqualTo("Hello");
+  }
+
+  @Test
+  void getUsesRequestedLocaleWhenAvailable() {
+    final LocaleReader englishReader = mockReader(Locale.ENGLISH, "greeting", "Hello");
+    final LocaleReader frenchReader = mockReader(Locale.FRENCH, "greeting", "Bonjour");
+    translator.add(englishReader);
+    translator.add(frenchReader);
+
+    assertThat(translator.get("greeting", Locale.FRENCH)).isEqualTo("Bonjour");
+  }
+
+  @Test
+  void laterAddedReaderTakesPriority() {
+    final LocaleReader first = mockReader(Locale.ENGLISH, "greeting", "Hello");
+    final LocaleReader second = mockReader(Locale.ENGLISH, "greeting", "Hi");
+    translator.add(first);
+    translator.add(second);
+
+    assertThat(translator.get("greeting")).isEqualTo("Hi");
+  }
+
+  @Test
+  void containsKeyForDefaultLocale() {
+    final LocaleReader reader = mockReader(Locale.ENGLISH, "greeting", "Hello");
+    translator.add(reader);
+
+    assertThat(translator.containsKey("greeting")).isTrue();
+    assertThat(translator.containsKey("missing")).isFalse();
+  }
+
+  @Test
+  void containsKeyForSpecificLocale() {
+    final LocaleReader reader = mockReader(Locale.FRENCH, "greeting", "Bonjour");
+    translator.add(reader);
+
+    assertThat(translator.containsKey("greeting", Locale.FRENCH)).isTrue();
+    assertThat(translator.containsKey("greeting", Locale.GERMAN)).isFalse();
+  }
+
+  @Test
+  void setLocaleChangesDefaultLookup() {
+    final LocaleReader frenchReader = mockReader(Locale.FRENCH, "greeting", "Bonjour");
+    translator.add(frenchReader);
+
+    assertThat(translator.get("greeting")).isEqualTo("greeting");
+
+    translator.setLocale(Locale.FRENCH);
+    assertThat(translator.get("greeting")).isEqualTo("Bonjour");
+  }
+
+  @Test
+  void clearRemovesAllBundles() {
+    final LocaleReader reader = mockReader(Locale.ENGLISH, "greeting", "Hello");
+    translator.add(reader);
+    assertThat(translator.get("greeting")).isEqualTo("Hello");
+
+    translator.clear();
+    assertThat(translator.get("greeting")).isEqualTo("greeting");
+  }
+
+  @Test
+  void getArrayReturnsArrayFromReader() {
+    final LocaleReader reader =
+        mockArrayReader(Locale.ENGLISH, "lore", new String[] {"Line 1", "Line 2", "Line 3"});
+    translator.add(reader);
+
+    assertThat(translator.getArray("lore")).containsExactly("Line 1", "Line 2", "Line 3");
+  }
+
+  @Test
+  void getArrayFallsBackToDefaultLocale() {
+    final LocaleReader reader =
+        mockArrayReader(Locale.ENGLISH, "lore", new String[] {"Line A", "Line B"});
+    translator.add(reader);
+
+    assertThat(translator.getArray("lore", Locale.FRENCH)).containsExactly("Line A", "Line B");
+  }
+
+  @Test
+  void getArrayReturnsSingleKeyWhenMissing() {
+    assertThat(translator.getArray("missing.lore")).containsExactly("missing.lore");
+  }
+
+  @Test
+  void concurrentAddAndGetDoesNotThrow() throws Exception {
+    final int threadCount = 20;
+    final CyclicBarrier barrier = new CyclicBarrier(threadCount);
+    final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    final List<Future<?>> futures = new ArrayList<>();
+
+    for (int i = 0; i < threadCount; i++) {
+      final int index = i;
+      futures.add(
+          executor.submit(
+              () -> {
+                try {
+                  barrier.await(5, TimeUnit.SECONDS);
+                } catch (final Exception e) {
+                  throw new RuntimeException(e);
+                }
+
+                if (index % 2 == 0) {
+                  final Locale locale = new Locale("lang" + index);
+                  final LocaleReader reader = mockReader(locale, "key" + index, "value" + index);
+                  translator.add(reader);
+                } else {
+                  translator.get("key" + index);
+                  translator.get("key" + index, Locale.ENGLISH);
+                  translator.containsKey("key" + index);
+                }
+              }));
+    }
+
+    for (final Future<?> future : futures) {
+      future.get(10, TimeUnit.SECONDS);
+    }
+
+    executor.shutdown();
+    assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+  }
+
+  private static LocaleReader mockReader(
+      final Locale locale, final String key, final String value) {
+    final LocaleReader reader = mock(LocaleReader.class);
+    when(reader.getLocale()).thenReturn(locale);
+    when(reader.containsKey(key)).thenReturn(true);
+    when(reader.get(key)).thenReturn(value);
+    return reader;
+  }
+
+  private static LocaleReader mockArrayReader(
+      final Locale locale, final String key, final String[] value) {
+    final LocaleReader reader = mock(LocaleReader.class);
+    when(reader.getLocale()).thenReturn(locale);
+    when(reader.containsKey(key)).thenReturn(true);
+    when(reader.getArray(key)).thenReturn(value);
+    return reader;
+  }
+}


### PR DESCRIPTION
- Replace HashMap with ConcurrentHashMap and CopyOnWriteArrayList in SimpleTranslator for thread-safe concurrent access
- Add case-insensitive locale normalization and hierarchical fallback in Locales.get() to handle Minecraft client formats (en_us, pt_br)
- Add FINE-level logging for missing translation keys and WARNING for empty resource bundle loads
- Expose getArray() on Translator interface for multi-line translations
- Add MenuButton.createLocalized() factory methods that resolve #{key} placeholders through the localization pipeline
- Document MessageFormat single-quote escaping requirements in Javadoc
- Add SimpleTranslatorTest and LocalesTest covering fallback chain, locale normalization, concurrency, and getArray()