### PR TITLE
build: add Maven Central publishing via NMCP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Fix Gradle wrapper permissions
+        run: chmod +x gradlew
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Run tests
+        run: ./gradlew check -PreleaseVersion=${{ steps.version.outputs.VERSION }}
+
+      - name: Publish to Maven Central
+        run: ./gradlew publishAggregationToCentralPortal -PreleaseVersion=${{ steps.version.outputs.VERSION }}
+        env:
+          ORG_GRADLE_PROJECT_centralPortalUsername: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+          ORG_GRADLE_PROJECT_centralPortalPassword: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}

--- a/buildSrc/src/main/kotlin/pluginbase-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/pluginbase-conventions.gradle.kts
@@ -3,13 +3,14 @@ import net.ltgt.gradle.errorprone.errorprone
 plugins {
     `java-library`
     `maven-publish`
+    signing
     id("com.gradleup.shadow")
     id("com.diffplug.spotless")
     id("net.ltgt.errorprone")
 }
 
-group = "dev.demeng"
-version = "1.37.0-SNAPSHOT"
+group = "dev.demeng.pluginbase"
+version = findProperty("releaseVersion") as String? ?: "0.0.0-SNAPSHOT"
 
 java {
     toolchain {
@@ -79,6 +80,43 @@ publishing {
             artifact(tasks.shadowJar)
             artifact(tasks.named("sourcesJar"))
             artifact(tasks.named("javadocJar"))
+            pom {
+                name.set(project.name)
+                description.set(provider { project.description ?: project.name })
+                url.set("https://github.com/demengc/PluginBase")
+                licenses {
+                    license {
+                        name.set("MIT License")
+                        url.set("https://opensource.org/licenses/MIT")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("demengc")
+                        name.set("Demeng")
+                        email.set("hi@demeng.dev")
+                        url.set("https://github.com/demengc")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:git://github.com/demengc/PluginBase.git")
+                    developerConnection.set("scm:git:ssh://github.com/demengc/PluginBase.git")
+                    url.set("https://github.com/demengc/PluginBase")
+                }
+            }
         }
     }
+}
+
+signing {
+    val signingKey = findProperty("signingInMemoryKey") as String?
+    val signingPassword = findProperty("signingInMemoryKeyPassword") as String?
+    if (signingKey != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+    }
+    sign(publishing.publications["shadow"])
+}
+
+tasks.withType<Sign>().configureEach {
+    isRequired = !version.toString().endsWith("-SNAPSHOT")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ shadow = "9.4.1"
 spotless = "8.4.0"
 errorprone-plugin = "5.1.0"
 errorprone-core = "2.35.1"
+nmcp = "1.4.4"
 
 spigot-api = "1.21.11-R0.1-SNAPSHOT"
 annotations = "26.1.0"
@@ -68,3 +69,4 @@ lamp = ["lamp-common", "lamp-bukkit", "lamp-brigadier"]
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 errorprone = { id = "net.ltgt.errorprone", version.ref = "errorprone-plugin" }
+nmcp-settings = { id = "com.gradleup.nmcp.settings", version.ref = "nmcp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,16 @@
+plugins {
+    id("com.gradleup.nmcp.settings") version "1.4.4"
+}
+
 rootProject.name = "pluginbase"
+
+nmcpSettings {
+    centralPortal {
+        username = providers.gradleProperty("centralPortalUsername")
+        password = providers.gradleProperty("centralPortalPassword")
+        publishingType = "AUTOMATIC"
+    }
+}
 
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)


### PR DESCRIPTION
Configure signing, POM metadata, and the NMCP settings plugin for publishing to Maven Central Portal.